### PR TITLE
Use file object to match the violations between report and source file

### DIFF
--- a/src/main/java/com/parasoft/findings/sonar/importer/AbstractSOAtestAndJtestTestsParser.java
+++ b/src/main/java/com/parasoft/findings/sonar/importer/AbstractSOAtestAndJtestTestsParser.java
@@ -56,7 +56,7 @@ abstract class AbstractSOAtestAndJtestTestsParser {
         XUnitTestsContainer xUnitTestsContainerOnProject = new XUnitTestsContainer();
         for (File report : reports) {
             try {
-                Logger.getLogger().info(NLS.getFormatted(Messages.ParsingXUnitReport, report));
+                Logger.getLogger().info(NLS.getFormatted(Messages.ParsingXUnitReport, report.getAbsoluteFile()));
                 xUnitTestsContainerOnProject.mergeFrom(xUnitSAXParser.parse(report));
             } catch (ParserConfigurationException | IOException | SAXException e) {
                 throw new InvalidReportException(NLS.getFormatted(Messages.FailedToParseXUnitReport, report), e);

--- a/src/main/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParser.java
+++ b/src/main/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParser.java
@@ -129,7 +129,7 @@ public class ParasoftIssuesParser
         }
         var findings = getFindings(source);
         if (CollectionUtil.isEmpty(findings)) {
-            Logger.getLogger().info(NLS.getFormatted(Messages.NoFindingsFor, sourceFile.toString()));
+            Logger.getLogger().info(NLS.getFormatted(Messages.NoFindingsFor, source.toString()));
             return 0;
         }
         int findingsCount = 0;

--- a/src/main/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParser.java
+++ b/src/main/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParser.java
@@ -54,7 +54,7 @@ public class ParasoftIssuesParser
 
     private XmlReportViolationsImporter _importer = null;
 
-    private final Map<String, Set<IRuleViolation>> _violations = Collections.synchronizedMap(new HashMap<>());
+    private final Map<File, Set<IRuleViolation>> _violations = Collections.synchronizedMap(new HashMap<>());
 
     /**
      * Creates a new instance of {@link ParasoftIssuesParser}.
@@ -84,22 +84,22 @@ public class ParasoftIssuesParser
                 }
                 ResultLocation location = violation.getResultLocation();
                 ITestableInput testableInput = location != null ? location.getTestableInput() : null;
-                String inputPath = null;
+                File inputFile = null;
                 if (testableInput != null) {
                     if (testableInput instanceof IFileTestableInput) {
-                        inputPath = ((IFileTestableInput) testableInput).getFileLocation().toURI().getPath();
+                        inputFile = new File(((IFileTestableInput) testableInput).getFileLocation().toURI().getPath()).getAbsoluteFile();
                     } else {
                         Logger.getLogger().error(NLS.getFormatted(Messages.InputIsNotInstanceOfIFileTestableInput, testableInput.getClass().getSimpleName()));
                     }
                 }
-                if (inputPath == null) {
+                if (inputFile == null) {
                     continue;
                 }
-                var violations = _violations.get(inputPath);
+                var violations = _violations.get(inputFile);
                 if (violations == null) {
                     violations = new HashSet<>();
-                    _violations.put(inputPath, violations);
-                    Logger.getLogger().info(NLS.getFormatted(Messages.AddedLocationWithFinding, inputPath));
+                    _violations.put(inputFile, violations);
+                    Logger.getLogger().info(NLS.getFormatted(Messages.AddedLocationWithFinding, inputFile));
                 }
                 violations.add(violation);
                 loadedFindings++;
@@ -113,16 +113,21 @@ public class ParasoftIssuesParser
         return loadedFindings;
     }
 
-    public Set<IRuleViolation> getFindings(String inputFilePath)
+    public Set<IRuleViolation> getFindings(File inputFile)
     {
-        return _violations.get(inputFilePath);
+        return _violations.get(inputFile);
     }
 
     public int createNewIssues(InputFile sourceFile, ParasoftProduct product, SensorContext context)
     {
         ActiveRules activeRules = context.activeRules();
-        String inputFilePath = sourceFile.uri().getPath();
-        var findings = getFindings(inputFilePath);
+        File source;
+        if (sourceFile.isFile()) {
+            source = new File(sourceFile.uri().getPath()).getAbsoluteFile();
+        } else {
+            return 0;
+        }
+        var findings = getFindings(source);
         if (CollectionUtil.isEmpty(findings)) {
             Logger.getLogger().info(NLS.getFormatted(Messages.NoFindingsFor, sourceFile.toString()));
             return 0;

--- a/src/main/java/com/parasoft/findings/sonar/sensor/AbstractParasoftFindingsSensor.java
+++ b/src/main/java/com/parasoft/findings/sonar/sensor/AbstractParasoftFindingsSensor.java
@@ -109,7 +109,7 @@ public abstract class AbstractParasoftFindingsSensor
         ParasoftDottestAndCpptestTestsParser testsParser = new ParasoftDottestAndCpptestTestsParser();
         TestSummary unitTestSummaryForProject = new TestSummary();
         for (var file : reportFiles.keySet()) {
-            Logger.getLogger().info(NLS.getFormatted(Messages.ParsingReportFile, Messages.UnitTest, file));
+            Logger.getLogger().info(NLS.getFormatted(Messages.ParsingReportFile, Messages.UnitTest, file.getAbsoluteFile()));
 
             TestSummary unitTestSummaryForReport = testsParser.loadTestResults(reportFiles.get(file));
 
@@ -134,7 +134,7 @@ public abstract class AbstractParasoftFindingsSensor
             return;
         }
         for (var file : reportFiles) {
-            Logger.getLogger().info(NLS.getFormatted(Messages.ParsingReportFile, Messages.StaticAnalysis, file));
+            Logger.getLogger().info(NLS.getFormatted(Messages.ParsingReportFile, Messages.StaticAnalysis, file.getAbsoluteFile()));
             loadFindings(file, findingsParser, context);
         }
     }

--- a/src/main/java/com/parasoft/findings/sonar/sensor/AbstractParasoftFindingsSensor.java
+++ b/src/main/java/com/parasoft/findings/sonar/sensor/AbstractParasoftFindingsSensor.java
@@ -182,7 +182,7 @@ public abstract class AbstractParasoftFindingsSensor
         for (var file : files) {
             var count = findingsParser.createNewIssues(file, _product, context);
             if (count > 0) {
-                Logger.getLogger().info(NLS.getFormatted(Messages.CreatedIssues, count, file.toString()));
+                Logger.getLogger().info(NLS.getFormatted(Messages.CreatedIssues, count, new File(file.uri().getPath()).getAbsoluteFile().toString()));
             }
         }
     }

--- a/src/test/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParserTest.java
+++ b/src/test/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParserTest.java
@@ -57,6 +57,7 @@ public class ParasoftIssuesParserTest {
         InputFile inputFile = mock(InputFile.class);
 
         // Test createNewIssues(InputFile sourceFile, ParasoftProduct product, SensorContext context)
+        when(inputFile.isFile()).thenReturn(true);
         when(inputFile.uri()).thenReturn(new URI("file:///D:/PARASOFT/src/sc3/parasoft-96505-repro/app/main.c"));
         result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
         assertEquals(0, result);
@@ -82,6 +83,7 @@ public class ParasoftIssuesParserTest {
         when(context.runtime()).thenReturn(sonarRuntime);
         when(context.activeRules()).thenReturn(activeRulesResult);
         InputFile inputFile = mock(InputFile.class);
+        when(inputFile.isFile()).thenReturn(true);
 
         NewIssue newIssueResult = mock(NewIssue.class);
         when(newIssueResult.overrideSeverity(nullable(org.sonar.api.batch.rule.Severity.class))).thenReturn(newIssueResult);
@@ -103,10 +105,38 @@ public class ParasoftIssuesParserTest {
         result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
         assertEquals(3, result);
 
+        when(inputFile.uri()).thenReturn(new URI("file://user/D:/PARASOFT/src/sc3/parasoft-96505-repro/app/main.c"));
+        result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+        assertEquals(3, result);
+
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            when(inputFile.uri()).thenReturn(new URI("file:///d:/PARASOFT/src/sc3/parasoft-96505-repro/app/main.c"));
+            result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+            assertEquals(3, result);
+
+            when(inputFile.uri()).thenReturn(new URI("file://user/d:/PARASOFT/src/sc3/parasoft-96505-repro/app/main.c"));
+            result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+            assertEquals(3, result);
+        }
+
         // Test createNewIssues(InputFile sourceFile, ParasoftProduct product, SensorContext context)
         when(version.isGreaterThanOrEqual(nullable(Version.class))).thenReturn(false);
         when(inputFile.uri()).thenReturn(new URI("file:/D:/PARASOFT/src/sc3/parasoft-96505-repro/bootloader/main.c"));
         result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
         assertEquals(3, result);
+
+        when(inputFile.uri()).thenReturn(new URI("file://user/D:/PARASOFT/src/sc3/parasoft-96505-repro/bootloader/main.c"));
+        result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+        assertEquals(3, result);
+
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            when(inputFile.uri()).thenReturn(new URI("file:/d:/PARASOFT/src/sc3/parasoft-96505-repro/bootloader/main.c"));
+            result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+            assertEquals(3, result);
+
+            when(inputFile.uri()).thenReturn(new URI("file://user/d:/PARASOFT/src/sc3/parasoft-96505-repro/bootloader/main.c"));
+            result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+            assertEquals(3, result);
+        }
     }
 }

--- a/src/test/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParserTest.java
+++ b/src/test/java/com/parasoft/findings/sonar/importer/ParasoftIssuesParserTest.java
@@ -138,5 +138,13 @@ public class ParasoftIssuesParserTest {
             result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
             assertEquals(3, result);
         }
+
+        when(inputFile.uri()).thenReturn(new URI("file:/d:/not/exist/in/report"));
+        result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+        assertEquals(0, result);
+
+        when(inputFile.isFile()).thenReturn(false);
+        result = parasoftIssuesParser.createNewIssues(inputFile, ParasoftProduct.CPPTEST, context);
+        assertEquals(0, result);
     }
 }

--- a/src/test/java/com/parasoft/findings/sonar/sensor/JtestFindingsSensorTest.java
+++ b/src/test/java/com/parasoft/findings/sonar/sensor/JtestFindingsSensorTest.java
@@ -55,7 +55,12 @@ public class JtestFindingsSensorTest {
         new JtestFindingsSensor(new XSLConverter(context.fileSystem()), new JtestTestsParser()).execute(context);
 
         assertThat(logTester.logs(Level.INFO)).contains("4 findings imported");
-        assertThat(logTester.logs(Level.INFO)).contains("Added location with finding(s): /D:/RWorkspaces/project-workspace/CICD/jtestdemo/src/main/java/parasoft/ForViolations.java");
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            assertThat(logTester.logs(Level.INFO)).contains("Added location with finding(s): D:\\RWorkspaces\\project-workspace\\CICD\\jtestdemo\\src\\main\\java\\parasoft\\ForViolations.java");
+        } else {
+            assertThat(logTester.logs(Level.INFO)).contains("Added location with finding(s): /D:/RWorkspaces/project-workspace/CICD/jtestdemo/src/main/java/parasoft/ForViolations.java");
+        }
+
         assertThat(logTester.logs(Level.ERROR   )).contains("No source files found");
     }
 

--- a/src/test/resources/cpptest/Cpptest-std-2023.1.1-static-report.xml
+++ b/src/test/resources/cpptest/Cpptest-std-2023.1.1-static-report.xml
@@ -28,8 +28,8 @@
    <Scope>
       <Repositories />
       <Locations>
-         <Loc auth="user-name" hash="-1471552250" locRef="1" projId="parasoft-96505-repro" projPath="/parasoft-96505-repro" project="parasoft-96505-repro" resProjPath="app/main.c" totLns="4" uri="file://PARASOFT/D:/PARASOFT/src/sc3/parasoft-96505-repro/app/main.c" />
-         <Loc auth="user-name" hash="-1120479048" locRef="2" projId="parasoft-96505-repro" projPath="/parasoft-96505-repro" project="parasoft-96505-repro" resProjPath="bootloader/main.c" totLns="9" uri="file://PARASOFT/D:/PARASOFT/src/sc3/parasoft-96505-repro/bootloader/main.c" />
+         <Loc auth="user-name" hash="-1471552250" locRef="1" projId="parasoft-96505-repro" projPath="/parasoft-96505-repro" project="parasoft-96505-repro" resProjPath="app/main.c" totLns="4" uri="file://user/D:/PARASOFT/src/sc3/parasoft-96505-repro/app/main.c" />
+         <Loc auth="user-name" hash="-1120479048" locRef="2" projId="parasoft-96505-repro" projPath="/parasoft-96505-repro" project="parasoft-96505-repro" resProjPath="bootloader/main.c" totLns="9" uri="file:///D:/PARASOFT/src/sc3/parasoft-96505-repro/bootloader/main.c" />
       </Locations>
    </Scope>
 


### PR DESCRIPTION
Fixed the issue of drive letter capitalization.